### PR TITLE
Fix a typo: "unicde" to "unicode"

### DIFF
--- a/subiquity/ui/views/welcome.py
+++ b/subiquity/ui/views/welcome.py
@@ -49,7 +49,7 @@ colours.
 
 If you are connecting from a terminal emulator such as gnome-terminal
 that supports unicode and rich colours you can switch to "rich mode"
-which uses unicde, colours and supports many languages.
+which uses unicode, colours and supports many languages.
 
 """
 


### PR DESCRIPTION
This is a tyny tipo fix PR which fixes "unicde" to "unicode" on the "Welcome!" screen when using a serial console.